### PR TITLE
bug fixes, new column names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,13 +15,13 @@ Depends:
     R(>= 2.10.0),
     magclass(>= 3.17),
     madrat(>= 1.72),
+    lpjclass(>= 1.15),
     mrcommons,
     mrland
 Imports:
     digest,
     dplyr,
     magpiesets,
-    lpjclass,
     luscale,
     ncdf4,
     raster,

--- a/R/calcSoilCharacteristics.R
+++ b/R/calcSoilCharacteristics.R
@@ -23,9 +23,10 @@ calcSoilCharacteristics <- function() {
     z[, i, ] <- x@.Data[, 1,1]
   }
 
+  soil_char <- toolGetMapping(name = "mappingSoil.csv", type = "sectoral")
   w = array(NA, dim = c(dim(x)[1], length(years), dim(soil_char[, -1])[2]),
             dimnames = list(1:dim(x)[1], years, dimnames(soil_char[, -1])[[2]]))
-  soil_char <- toolGetMapping(name = "mappingSoil.csv", type = "sectoral")
+
   for (i in 1:length(years)) {
     y           <- as.data.frame(z@.Data[, i, ])
     colnames(y) <- "soil"

--- a/R/readCO2Atmosphere.R
+++ b/R/readCO2Atmosphere.R
@@ -37,7 +37,7 @@ readCO2Atmosphere <-
     }
 
     x  <- clean_magpie(collapseNames(as.magpie(x, spatial = 1)))
-    getNames(x) <- subtype
+    getNames(x) <- paste("CO2ATMconcentration",subtype, sep = "_")
     getCells(x) <- "GLO"
 
     return(x)

--- a/R/readGCMClimate.R
+++ b/R/readGCMClimate.R
@@ -18,9 +18,9 @@
 readGCMClimate <-
   function(subtype = "GCMClimate:rcp85:HadGEM2.temperature") {
     if (grepl("\\.", subtype) & grepl("\\:", subtype)) {
-      subtype     <- strsplit(gsub(":", "/" , subtype), split = "\\.")
-      folder      <- unlist(subtype)[1]
-      subtype     <- unlist(subtype)[2]
+      type     <- strsplit(gsub(":", "/" , subtype), split = "\\.")
+      folder      <- unlist(type)[1]
+      subtype     <- unlist(type)[2]
 
     } else {
 
@@ -54,7 +54,8 @@ readGCMClimate <-
 
       x <- collapseNames(as.magpie(x))
       x <- x / 12
-      getNames(x) <- subtype
+      col_name <-  unlist(strsplit(unlist(type)[1], split = "\\/"))[c(1,2)]
+      getNames(x) <- paste(subtype,col_name[1],col_name[2], sep = "_")
 
     } else if (subtype %in% c("longwave_radiation", "shortwave_radiation")) {
       x <- read.LPJ_input(file_name = paste0(folder, "/", file_name),
@@ -62,7 +63,8 @@ readGCMClimate <-
                           namesum = TRUE)
       x <- collapseNames(as.magpie(x))
       x <- x / 365
-      getNames(x) <- subtype
+      col_name <-  unlist(strsplit(unlist(type)[1], split = "\\/"))[c(1,2)]
+      getNames(x) <- paste(subtype,col_name[1],col_name[2], sep = "_")
 
     } else {
       stop(paste0("subtype ", subtype, " is not existing"))
@@ -71,4 +73,3 @@ readGCMClimate <-
     return(x)
 
   }
-


### PR DESCRIPTION
I added an important version requirement in the description file (LPJclass >= 1.5), change the naming conventions of some columns to reflect the GCM and the RCP pathway in the readGCM function and fixed a bug in the calc function for the soil characteristics.