### PR TITLE
left_join dply version 1.0.0 bug fix

### DIFF
--- a/R/calcSoilCharacteristics.R
+++ b/R/calcSoilCharacteristics.R
@@ -30,7 +30,7 @@ calcSoilCharacteristics <- function() {
   for (i in 1:length(years)) {
     y           <- as.data.frame(z@.Data[, i, ])
     colnames(y) <- "soil"
-    y           <- left_join(y, soil_char, by = "soil", keep = TRUE)
+    y           <- left_join(y, soil_char, by = "soil", keep = F)
     y           <- data.matrix(y[, -1])
     w[, i, ]    <- y
   }


### PR DESCRIPTION
After an update on the dplyr package, I had to change a parameter in the left_join function that is now duplication the joining column for each dataframe.