### PR TITLE
comply with new convention to have column names "region", "country", "superregion" in mappings

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '29386880'
+ValidationKey: '29412660'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package .* was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrmagpie: madrat based MAgPIE Input Data Library'
-version: 1.48.0
-date-released: '2024-05-13'
+version: 1.48.1
+date-released: '2024-05-17'
 abstract: Provides functions for MAgPIE country and cellular input data generation.
 authors:
 - family-names: Karstens

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrmagpie
 Title: madrat based MAgPIE Input Data Library
-Version: 1.48.0
-Date: 2024-05-13
+Version: 1.48.1
+Date: 2024-05-17
 Authors@R: c(
     person("Kristine", "Karstens", , "karstens@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/toolApplyRegionNames.R
+++ b/R/toolApplyRegionNames.R
@@ -33,15 +33,18 @@ toolApplyRegionNames <- function(cdata, regionscode) {
 
   # Get countries from magpie object and extend mapping
   isocountries <- getItems(cdata, dim = 1.3, full = TRUE)
-  isoMap       <- data.frame(CountryCode = isocountries)
-  map          <- base::merge(isoMap, map, by = "CountryCode",
+  isoMap       <- data.frame(country = isocountries)
+  # rename column names from old to new convention, if necessary
+  if ("CountryCode" %in% names(map)) names(map)[names(map) == "CountryCode"] <- "country"
+  if ("RegionCode" %in% names(map)) names(map)[names(map) == "RegionCode"] <- "region"
+  map          <- base::merge(isoMap, map, by = "country",
                               all.x = TRUE, sort = FALSE, no.dups = TRUE)
   # correct cell order
-  map          <- map[match(isocountries, map$CountryCode), ]
+  map          <- map[match(isocountries, map$country), ]
 
   # Add regional information to magpie object
   getItems(cdata, dim = 1, raw = TRUE) <- paste(gsub(".*\\.", "", getItems(cdata, dim = 1)),
-                                                map$RegionCode,
+                                                map$region,
                                                 as.character(seq_along(isocountries)),
                                                 sep = ".")
   getSets(cdata, fulldim = FALSE)[1] <- "country.region.cell"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # madrat based MAgPIE Input Data Library
 
-R package **mrmagpie**, version **1.48.0**
+R package **mrmagpie**, version **1.48.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrmagpie)](https://cran.r-project.org/package=mrmagpie) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4319612.svg)](https://doi.org/10.5281/zenodo.4319612) [![R build status](https://github.com/pik-piam/mrmagpie/workflows/check/badge.svg)](https://github.com/pik-piam/mrmagpie/actions) [![codecov](https://codecov.io/gh/pik-piam/mrmagpie/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrmagpie) [![r-universe](https://pik-piam.r-universe.dev/badges/mrmagpie)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Kristine Karstens <karstens@pik-p
 
 To cite package **mrmagpie** in publications use:
 
-Karstens K, Dietrich J, Chen D, Windisch M, Alves M, Beier F, Köberle A, v. Jeetze P, Mishra A, Humpenoeder F, Sauer P (2024). _mrmagpie: madrat based MAgPIE Input Data Library_. doi:10.5281/zenodo.4319612 <https://doi.org/10.5281/zenodo.4319612>, R package version 1.48.0, <https://github.com/pik-piam/mrmagpie>.
+Karstens K, Dietrich J, Chen D, Windisch M, Alves M, Beier F, Köberle A, v. Jeetze P, Mishra A, Humpenoeder F, Sauer P (2024). _mrmagpie: madrat based MAgPIE Input Data Library_. doi: 10.5281/zenodo.4319612 (URL: https://doi.org/10.5281/zenodo.4319612), R package version 1.48.1, <URL: https://github.com/pik-piam/mrmagpie>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,8 +48,8 @@ A BibTeX entry for LaTeX users is
   title = {mrmagpie: madrat based MAgPIE Input Data Library},
   author = {Kristine Karstens and Jan Philipp Dietrich and David Chen and Michael Windisch and Marcos Alves and Felicitas Beier and Alexandre Köberle and Patrick {v. Jeetze} and Abhijeet Mishra and Florian Humpenoeder and Pascal Sauer},
   year = {2024},
-  note = {R package version 1.48.0},
-  url = {https://github.com/pik-piam/mrmagpie},
+  note = {R package version 1.48.1},
   doi = {10.5281/zenodo.4319612},
+  url = {https://github.com/pik-piam/mrmagpie},
 }
 ```


### PR DESCRIPTION
The new convention of the column names in mappings is to use "country", "region", "superregion". This MR changes the toolApplyRegionNames in a way to use these new column names. If the column names in the old convention  "CountryCode" "RegionCode" are provided they are automatically replaced by those of the new convention.

It was tested that this MR fixes an error in the H16s5 preprocessing, while not crashing H12 preprocessing. See for h12
```rev4.106h12_David_test_change_in_toolApplyRegionNames_h12_magpie.tgz```, ```rev4.106h12_David_test_change_in_toolApplyRegionNames_h12_validation.tgz```,
```rev4.106h12_David_test_change_in_toolApplyRegionNames_h12_bd86374e_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1_clusterweight-ba4466a8.tgz```,

and for h16s5

```rev4.106h16s5_David_test_change_in_toolApplyRegionNames_1028489d_magpie.tgz```
```rev4.106h16s5_David_test_change_in_toolApplyRegionNames_1028489d_validation.tgz```
```rev4.106h16s5_David_test_change_in_toolApplyRegionNames_1028489d_bd86374e_cellularmagpie_c200_MRI-ESM2-0-ssp370_lpjml-8e6c5eb1_clusterweight-ba4466a8.tgz```.

Version h16 was not tested but should also work, due to similarity with h16s5.
