### PR TITLE
Activate statistics collection for fullCellularMagpie

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '31877161'
+ValidationKey: '32061360'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package .* was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrmagpie: madrat based MAgPIE Input Data Library'
-version: 1.57.1
-date-released: '2025-07-22'
+version: 1.58.0
+date-released: '2025-07-23'
 abstract: Provides functions for MAgPIE country and cellular input data generation.
 authors:
 - family-names: Karstens

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrmagpie
 Title: madrat based MAgPIE Input Data Library
-Version: 1.57.1
-Date: 2025-07-22
+Version: 1.58.0
+Date: 2025-07-23
 Authors@R: c(
     person("Kristine", "Karstens", , "karstens@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/fullCELLULARMAGPIE.R
+++ b/R/fullCELLULARMAGPIE.R
@@ -28,7 +28,8 @@
 #'
 #' @author Kristine Karstens, Jan Philipp Dietrich
 #' @seealso
-#' \code{\link[madrat]{readSource}},\code{\link[madrat]{getCalculations}},\code{\link[madrat]{calcOutput}},\code{\link[madrat]{setConfig}}
+#' \code{\link[madrat]{readSource}},\code{\link[madrat]{getCalculations}},\code{\link[madrat]{calcOutput}},
+#' \code{\link[madrat]{setConfig}}
 #' @examples
 #' \dontrun{
 #' retrieveData("CELLULARMAGPIE", rev = numeric_version("12"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # madrat based MAgPIE Input Data Library
 
-R package **mrmagpie**, version **1.57.1**
+R package **mrmagpie**, version **1.58.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrmagpie)](https://cran.r-project.org/package=mrmagpie) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4319612.svg)](https://doi.org/10.5281/zenodo.4319612) [![R build status](https://github.com/pik-piam/mrmagpie/workflows/check/badge.svg)](https://github.com/pik-piam/mrmagpie/actions) [![codecov](https://codecov.io/gh/pik-piam/mrmagpie/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrmagpie) [![r-universe](https://pik-piam.r-universe.dev/badges/mrmagpie)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Kristine Karstens <karstens@pik-p
 
 To cite package **mrmagpie** in publications use:
 
-Karstens K, Dietrich J, Chen D, Windisch M, Alves M, Beier F, Köberle A, v. Jeetze P, Mishra A, Humpenoeder F, Sauer P (2025). "mrmagpie: madrat based MAgPIE Input Data Library." doi:10.5281/zenodo.4319612 <https://doi.org/10.5281/zenodo.4319612>, Version: 1.57.1, <https://github.com/pik-piam/mrmagpie>.
+Karstens K, Dietrich J, Chen D, Windisch M, Alves M, Beier F, Köberle A, v. Jeetze P, Mishra A, Humpenoeder F, Sauer P (2025). "mrmagpie: madrat based MAgPIE Input Data Library." doi:10.5281/zenodo.4319612 <https://doi.org/10.5281/zenodo.4319612>, Version: 1.58.0, <https://github.com/pik-piam/mrmagpie>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {mrmagpie: madrat based MAgPIE Input Data Library},
   author = {Kristine Karstens and Jan Philipp Dietrich and David Chen and Michael Windisch and Marcos Alves and Felicitas Beier and Alexandre Köberle and Patrick {v. Jeetze} and Abhijeet Mishra and Florian Humpenoeder and Pascal Sauer},
   doi = {10.5281/zenodo.4319612},
-  date = {2025-07-22},
+  date = {2025-07-23},
   year = {2025},
   url = {https://github.com/pik-piam/mrmagpie},
-  note = {Version: 1.57.1},
+  note = {Version: 1.58.0},
 }
 ```

--- a/man/fullCELLULARMAGPIE.Rd
+++ b/man/fullCELLULARMAGPIE.Rd
@@ -59,7 +59,8 @@ retrieveData("CELLULARMAGPIE", rev = numeric_version("12"),
 }
 }
 \seealso{
-\code{\link[madrat]{readSource}},\code{\link[madrat]{getCalculations}},\code{\link[madrat]{calcOutput}},\code{\link[madrat]{setConfig}}
+\code{\link[madrat]{readSource}},\code{\link[madrat]{getCalculations}},\code{\link[madrat]{calcOutput}},
+\code{\link[madrat]{setConfig}}
 }
 \author{
 Kristine Karstens, Jan Philipp Dietrich


### PR DESCRIPTION
This PR only activates statistics collection for `fullCellularMagpie`. This involves adding the `outputStatistics` argument to all `calcOutput` calls as well as writing the `status.log` at the end.