### PR TITLE
Changes the kmeans algorithm to MacQueen

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '32109854'
+ValidationKey: '32131734'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package .* was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrmagpie: madrat based MAgPIE Input Data Library'
-version: 1.58.2
-date-released: '2025-07-28'
+version: 1.58.3
+date-released: '2025-07-29'
 abstract: Provides functions for MAgPIE country and cellular input data generation.
 authors:
 - family-names: Karstens

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrmagpie
 Title: madrat based MAgPIE Input Data Library
-Version: 1.58.2
-Date: 2025-07-28
+Version: 1.58.3
+Date: 2025-07-29
 Authors@R: c(
     person("Kristine", "Karstens", , "karstens@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),

--- a/R/calcClusterKMeans.R
+++ b/R/calcClusterKMeans.R
@@ -47,7 +47,9 @@ calcClusterKMeans <- function(regionscode, ncluster, weight = NULL, cpr = NULL, 
   set.seed(seed)
   for (r in dimnames(cpr)[[1]]) {
     cells <- grep(paste0(".", r, "."), dimnames(cdata)[[1]], fixed = TRUE)
-    fit <- kmeans(cdata[cells, ], cpr[r, "clusters"], iter.max = 10000)
+    # We use the MacQueen algorithm as the HartiganWong algorithm does not converge reliably, as some
+    # points in cdata are very close.
+    fit <- kmeans(cdata[cells, ], cpr[r, "clusters"], iter.max = 50000, algorithm = "MacQueen")
     getCells(out)[cells] <- paste(getCells(out)[cells], fit$cluster + ccount, sep = ".")
     ccount <- ccount + cpr[r, "clusters"]
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # madrat based MAgPIE Input Data Library
 
-R package **mrmagpie**, version **1.58.2**
+R package **mrmagpie**, version **1.58.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrmagpie)](https://cran.r-project.org/package=mrmagpie) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4319612.svg)](https://doi.org/10.5281/zenodo.4319612) [![R build status](https://github.com/pik-piam/mrmagpie/workflows/check/badge.svg)](https://github.com/pik-piam/mrmagpie/actions) [![codecov](https://codecov.io/gh/pik-piam/mrmagpie/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrmagpie) [![r-universe](https://pik-piam.r-universe.dev/badges/mrmagpie)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Kristine Karstens <karstens@pik-p
 
 To cite package **mrmagpie** in publications use:
 
-Karstens K, Dietrich J, Chen D, Windisch M, Alves M, Beier F, Köberle A, v. Jeetze P, Mishra A, Humpenoeder F, Sauer P (2025). "mrmagpie: madrat based MAgPIE Input Data Library." doi:10.5281/zenodo.4319612 <https://doi.org/10.5281/zenodo.4319612>, Version: 1.58.2, <https://github.com/pik-piam/mrmagpie>.
+Karstens K, Dietrich J, Chen D, Windisch M, Alves M, Beier F, Köberle A, v. Jeetze P, Mishra A, Humpenoeder F, Sauer P (2025). "mrmagpie: madrat based MAgPIE Input Data Library." doi:10.5281/zenodo.4319612 <https://doi.org/10.5281/zenodo.4319612>, Version: 1.58.3, <https://github.com/pik-piam/mrmagpie>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {mrmagpie: madrat based MAgPIE Input Data Library},
   author = {Kristine Karstens and Jan Philipp Dietrich and David Chen and Michael Windisch and Marcos Alves and Felicitas Beier and Alexandre Köberle and Patrick {v. Jeetze} and Abhijeet Mishra and Florian Humpenoeder and Pascal Sauer},
   doi = {10.5281/zenodo.4319612},
-  date = {2025-07-28},
+  date = {2025-07-29},
   year = {2025},
   url = {https://github.com/pik-piam/mrmagpie},
-  note = {Version: 1.58.2},
+  note = {Version: 1.58.3},
 }
 ```


### PR DESCRIPTION
This PR changes the kmeans algorithm to MacQueen as HartiganWong does not deal well with input values that are very close to each other. There are potential but minor changes to the resulting clusters.