### PR TITLE
Improve creation of similarity matrix in ClusterBase 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '32131734'
+ValidationKey: '32155200'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package .* was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrmagpie: madrat based MAgPIE Input Data Library'
-version: 1.58.3
-date-released: '2025-07-29'
+version: 1.58.4
+date-released: '2025-07-31'
 abstract: Provides functions for MAgPIE country and cellular input data generation.
 authors:
 - family-names: Karstens
@@ -36,6 +36,9 @@ authors:
 - family-names: Sauer
   given-names: Pascal
   email: pascal.sauer@pik-potsdam.de
+- family-names: Rein
+  given-names: Patrick
+  email: patrick.rein@pik-potsdam.de
 license: LGPL-3.0
 repository-code: https://github.com/pik-piam/mrmagpie
 doi: 10.5281/zenodo.4319612

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrmagpie
 Title: madrat based MAgPIE Input Data Library
-Version: 1.58.3
-Date: 2025-07-29
+Version: 1.58.4
+Date: 2025-07-31
 Authors@R: c(
     person("Kristine", "Karstens", , "karstens@pik-potsdam.de", role = c("aut", "cre")),
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = "aut"),
@@ -14,7 +14,8 @@ Authors@R: c(
     person("Patrick", "v. Jeetze", , "vjeetze@pik-potsdam.de", role = "aut"),
     person("Abhijeet", "Mishra", , "mishra@pik-potsdam.de", role = "aut"),
     person("Florian", "Humpenoeder", , "humpenoeder@pik-potsdam.de", role = "aut"),
-    person("Pascal", "Sauer", , "pascal.sauer@pik-potsdam.de", role = "aut")
+    person("Pascal", "Sauer", , "pascal.sauer@pik-potsdam.de", role = "aut"),
+    person("Patrick", "Rein", , "patrick.rein@pik-potsdam.de", role = "aut")
   )
 Description: Provides functions for MAgPIE country and cellular input data
     generation.

--- a/R/calcClusterBase.R
+++ b/R/calcClusterBase.R
@@ -45,9 +45,22 @@ calcClusterBase <- function(clusterdata = "yield_airrig",
           or yield_increment (new clustering data)")
   }
 
-  cdata <- do.call(cbind, lapply(d, wrap, list(1, c(2, 3))))
-  cdata <- cdata[, colSums(cdata) != 0]
-  cdata <- scale(cdata)
+  # Unify structures
+  d$gp <- setNames(d$gp, paste0("pop", seq_len(ndata(d$gp))))
+  d$yld <- setNames(d$yld, sub(".", "_", getNames(d$yld), fixed = TRUE))
+  d <- lapply(d, function(m) {
+    # Ensure all datasets have 1995 as the year (they should have been selected for that)
+    m <- setYears(m, "y1995")
+    getSets(m, fulldim = FALSE)[3] <- "data"
+    m
+  })
+
+  # Combine into one object
+  cdata <- do.call(mbind, d)
+  cdata <- cdata[, , dimSums(cdata, dim = c(1, 2)) != 0]
+  cdata <- wrap(cdata, list(1, c(2, 3)))
+
+  cdata <- scale(cdata) # We leave magpie land
   colnames(cdata) <- paste0("i", seq_len(ncol(cdata)))
 
   # Transform to magpie object

--- a/R/calcClusterBase.R
+++ b/R/calcClusterBase.R
@@ -52,7 +52,7 @@ calcClusterBase <- function(clusterdata = "yield_airrig",
     # Ensure all datasets have 1995 as the year (they should have been selected for that)
     m <- setYears(m, "y1995")
     getSets(m, fulldim = FALSE)[3] <- "data"
-    m
+    return(m)
   })
 
   # Combine into one object
@@ -60,7 +60,7 @@ calcClusterBase <- function(clusterdata = "yield_airrig",
   cdata <- cdata[, , dimSums(cdata, dim = c(1, 2)) != 0]
   cdata <- wrap(cdata, list(1, c(2, 3)))
 
-  cdata <- scale(cdata) # We leave magpie land
+  cdata <- scale(cdata) # Scale converts the magpie object to a matrix
   colnames(cdata) <- paste0("i", seq_len(ncol(cdata)))
 
   # Transform to magpie object

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # madrat based MAgPIE Input Data Library
 
-R package **mrmagpie**, version **1.58.3**
+R package **mrmagpie**, version **1.58.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrmagpie)](https://cran.r-project.org/package=mrmagpie) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4319612.svg)](https://doi.org/10.5281/zenodo.4319612) [![R build status](https://github.com/pik-piam/mrmagpie/workflows/check/badge.svg)](https://github.com/pik-piam/mrmagpie/actions) [![codecov](https://codecov.io/gh/pik-piam/mrmagpie/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrmagpie) [![r-universe](https://pik-piam.r-universe.dev/badges/mrmagpie)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,18 +39,18 @@ In case of questions / problems please contact Kristine Karstens <karstens@pik-p
 
 To cite package **mrmagpie** in publications use:
 
-Karstens K, Dietrich J, Chen D, Windisch M, Alves M, Beier F, Köberle A, v. Jeetze P, Mishra A, Humpenoeder F, Sauer P (2025). "mrmagpie: madrat based MAgPIE Input Data Library." doi:10.5281/zenodo.4319612 <https://doi.org/10.5281/zenodo.4319612>, Version: 1.58.3, <https://github.com/pik-piam/mrmagpie>.
+Karstens K, Dietrich J, Chen D, Windisch M, Alves M, Beier F, Köberle A, v. Jeetze P, Mishra A, Humpenoeder F, Sauer P, Rein P (2025). "mrmagpie: madrat based MAgPIE Input Data Library." doi:10.5281/zenodo.4319612 <https://doi.org/10.5281/zenodo.4319612>, Version: 1.58.4, <https://github.com/pik-piam/mrmagpie>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
   title = {mrmagpie: madrat based MAgPIE Input Data Library},
-  author = {Kristine Karstens and Jan Philipp Dietrich and David Chen and Michael Windisch and Marcos Alves and Felicitas Beier and Alexandre Köberle and Patrick {v. Jeetze} and Abhijeet Mishra and Florian Humpenoeder and Pascal Sauer},
+  author = {Kristine Karstens and Jan Philipp Dietrich and David Chen and Michael Windisch and Marcos Alves and Felicitas Beier and Alexandre Köberle and Patrick {v. Jeetze} and Abhijeet Mishra and Florian Humpenoeder and Pascal Sauer and Patrick Rein},
   doi = {10.5281/zenodo.4319612},
-  date = {2025-07-29},
+  date = {2025-07-31},
   year = {2025},
   url = {https://github.com/pik-piam/mrmagpie},
-  note = {Version: 1.58.3},
+  note = {Version: 1.58.4},
 }
 ```

--- a/man/mrmagpie-package.Rd
+++ b/man/mrmagpie-package.Rd
@@ -32,6 +32,7 @@ Authors:
   \item Abhijeet Mishra \email{mishra@pik-potsdam.de}
   \item Florian Humpenoeder \email{humpenoeder@pik-potsdam.de}
   \item Pascal Sauer \email{pascal.sauer@pik-potsdam.de}
+  \item Patrick Rein \email{patrick.rein@pik-potsdam.de}
 }
 
 }


### PR DESCRIPTION
This PR changes the creation of the similarity matrix to use magpie objects as long as possible to prevent issues such as the one fixed in #53 

The changes should preserve the result of the transformation.